### PR TITLE
fix boards architecture type

### DIFF
--- a/package_esp32_index.json
+++ b/package_esp32_index.json
@@ -5,7 +5,7 @@
       "help": {
         "online": "http://esp32.com"
       }, 
-      "websiteURL": "https://github.com/espressif/esp32-arduino", 
+      "websiteURL": "https://github.com/espressif/arduino-esp32",
       "platforms": [
 		{
           "category": "ESP32", 

--- a/package_esp32_index.json
+++ b/package_esp32_index.json
@@ -15,7 +15,7 @@
           "url": "https://raw.githubusercontent.com/DFRobot/FireBeetle-ESP32/master/DFRobot_FireBeetle-ESP32-0.0.6.zip", 
           "checksum": "SHA-256:4890bf15a56697bafa71aa307a946d1518bec3f0d138419d97c12c844c1ffb46",
           "version": "0.0.6", 
-          "architecture": "DFRobot_FireBeetle-ESP32", 
+          "architecture": "esp32",
           "archiveFileName": "DFRobot_FireBeetle-ESP32-0.0.6.zip", 
           "boards": [
             {


### PR DESCRIPTION
According to the official specification, Firebeetle-ESP32's architecture should be changed to esp32.
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5-3rd-party-Hardware-specification

This is can fix the error as below:

Multiple libraries were found for "WiFi.h"
Used: C:\Program Files (x86)\Arduino\libraries\WiFi
Not used: C:\Users\msi-\AppData\Local\Arduino15\packages\esp32\hardware\DFRobot_FireBeetle-ESP32\0.0.7\libraries\WiFi

It also appeared on espressif official repos:
https://github.com/espressif/arduino-esp32/issues/20

The comments below is very useful:
The Arduino IDE uses the architectures value in library.properties as one of the criteria for deciding library include priorities. The architecture of the board is determined by the architecture folder of the hardware package. As you can see, @Sweet-Peas did not correctly follow the installation instructions, causing the architecture folder to be named arduino-esp32 rather than esp32: